### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/parumtronics/firmwarec.png?label=ready&title=Ready)](https://waffle.io/parumtronics/firmwarec)
 # firmwarec
 
 [![Gitter](https://badges.gitter.im/parumtronics/firmwarec.svg)](https://gitter.im/parumtronics/firmwarec?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/parumtronics/firmwarec

This was requested by a real person (user euripedesrocha) on waffle.io, we're not trying to spam you.
